### PR TITLE
Fix links to source code in intersect.ts.md

### DIFF
--- a/src/intersect.ts.md
+++ b/src/intersect.ts.md
@@ -27,8 +27,8 @@ on this page are also written in TypeScript, using the library.
 
 [real-time collision detection]: http://realtimecollisiondetection.net/
 [algorithms]: http://www.realtimerendering.com/intersections.html
-[intersect.ts]: https://github.com/noonat/intersect/blob/master/src/intersect.js
-[examples.ts]: https://github.com/noonat/intersect/blob/master/src/examples.js
+[intersect.ts]: https://github.com/noonat/intersect/blob/master/src/intersect.ts
+[examples.ts]: https://github.com/noonat/intersect/blob/master/src/examples.ts
 
 ## Helpers
 


### PR DESCRIPTION
The references for [intersect.ts] and [examples.ts] erroneously link to .js files, which don't exist and show a 404 on https://noonat.github.io/intersect/

This patch changes those links to use the proper .ts URLs.